### PR TITLE
Fix #9: hide conflicting SelectionDetails class

### DIFF
--- a/lib/src/widgets/default_place_widget.dart
+++ b/lib/src/widgets/default_place_widget.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide SelectionDetails;
 import 'package:ultra_map_place_picker/src/enums.dart';
 import 'package:ultra_map_place_picker/src/models/ultra_circle_model.dart';
 import 'package:ultra_map_place_picker/src/models/pick_result_model.dart';


### PR DESCRIPTION
Flutter 3.29.0 adds a new class named SelectionDetails that conflicts with the existing class of this pacakge.
This commit hides the Flutter class so that the package class is used.